### PR TITLE
OXT-1676: Amend access_control tests.

### DIFF
--- a/dom0/access_control.bats
+++ b/dom0/access_control.bats
@@ -9,13 +9,13 @@
 }
 
 @test "no kernel classes/permissions left undefined in the SELinux policy" {
-    count=$(grep SELinux.*not defined /var/log/messages|wc -l)
+    count=$(grep 'SELinux.*not defined' /var/log/messages | wc -l)
 
     [ "${count}" -eq 0 ]
 }
 
 @test "no avc messages in /var/log/messages" {
-    count=$(grep avc:.*denied /var/log/messages|wc -l)
+    count=$(grep 'avc:.*denied' /var/log/messages | wc -l)
 
     [ "${count}" -eq 0 ]
 }

--- a/dom0/access_control.bats
+++ b/dom0/access_control.bats
@@ -35,6 +35,11 @@
 }
 
 @test "check SyncVM flask label" {
+    local type="$(xec-vm -n syncvm -g type 2>/dev/null)"
+    if [ "${type}" != "syncvm" ]; then
+        skip "SyncVM is not deployed."
+    fi
+
     run xec-vm -n syncvm -g flask-label
 
     [ "$status" -eq 0 ]

--- a/dom0/access_control.bats
+++ b/dom0/access_control.bats
@@ -5,7 +5,7 @@
 }
 
 @test "check XSM enforcing" {
-    [ "$(xenops getenforce)" = "Enforcing" ]
+    [ "$(xl getenforce)" = "Enforcing" ]
 }
 
 @test "no kernel classes/permissions left undefined in the SELinux policy" {


### PR DESCRIPTION
- Use `xl` instead of `xenops`.
- Add quotes to grep statements
- Skip out the SyncVM related test for now.