### PR TITLE
OXT-1693: fix the test case for XSM being enforcing

### DIFF
--- a/dom0/access_control.bats
+++ b/dom0/access_control.bats
@@ -5,7 +5,7 @@
 }
 
 @test "check XSM enforcing" {
-    [ "$(xenops getenforce)" = "Enforcing" ]
+    [ "$(xl getenforce)" = "Enforcing" ]
 }
 
 @test "no kernel classes/permissions left undefined in the SELinux policy" {


### PR DESCRIPTION
The test case was invoking the 'xenops' tool which is no longer
available in dom0. The same operation is now available via 'xl',
so update the test case to use that.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>